### PR TITLE
Load email recipients from Azure SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains:
 
 - Rich text editor for HTML body
 - Insert local image files into editor as inline base64 images
-- To/Subject fields
+- Subject field
+- Recipient addresses are loaded by the backend from Azure SQL active WFM Administrators
 - Calls backend endpoint `POST /api/mail/send`
 
 ### Run
@@ -43,6 +44,54 @@ Configure these values in `email-composer-backend/appsettings.Development.json` 
 
 The Azure app registration requires **Application** permissions such as `Mail.Send`, with admin consent.
 
+### Azure SQL configuration
+
+Configure the Azure SQL connection string in `email-composer-backend/appsettings.Development.json` or with the
+`ConnectionStrings__AzureSqlDatabase` environment variable:
+
+```json
+"ConnectionStrings": {
+  "AzureSqlDatabase": "Server=tcp:<server>.database.windows.net,1433;Initial Catalog=<database>;Persist Security Info=False;User ID=<user>;Password=<password>;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+}
+```
+
+The backend uses this query to select recipient email addresses:
+
+```sql
+WITH WorkerRoles AS (
+    SELECT
+        Worker.[Id] AS WorkerId,
+        Worker.[Role] AS RoleName
+    FROM [dbo].[Worker] Worker
+    UNION
+    SELECT
+        Worker.[Id] AS WorkerId,
+        WR.[Name] AS RoleName
+    FROM [dbo].[Worker] Worker
+    LEFT JOIN [dbo].[WorkerRoleAssignment] WRA ON WRA.[WorkerId] = Worker.[Id]
+    INNER JOIN [dbo].[WorkerRole] WR ON WR.[Id] = WRA.[RoleId]
+),
+WorkerRolesAgg AS (
+    SELECT
+        WorkerId,
+        STRING_AGG(RoleName, ', ') AS Roles
+    FROM WorkerRoles
+    GROUP BY WorkerId
+),
+CompanyActiveWfmAdmins AS (
+    SELECT
+        Worker.[EmailAddress]
+    FROM [dbo].[Worker] Worker
+    INNER JOIN WorkerRoles ON WorkerRoles.WorkerId = Worker.[Id]
+    WHERE WorkerRoles.RoleName = 'WFM Administrator' AND Worker.[Status] = 'A'
+)
+SELECT DISTINCT
+    EmailAddress
+FROM CompanyActiveWfmAdmins
+WHERE EmailAddress IS NOT NULL AND LTRIM(RTRIM(EmailAddress)) <> ''
+ORDER BY EmailAddress;
+```
+
 ### Run
 
 ```bash
@@ -60,7 +109,6 @@ Backend listens on `http://localhost:5000` by default via launch settings.
 ```json
 {
   "subject": "Hello",
-  "bodyHtml": "<p>Message body</p>",
-  "toRecipients": ["person@contoso.com"]
+  "bodyHtml": "<p>Message body</p>"
 }
 ```

--- a/email-composer-backend/EmailComposer.Backend.csproj
+++ b/email-composer-backend/EmailComposer.Backend.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 </Project>

--- a/email-composer-backend/EmailComposer.Backend.csproj
+++ b/email-composer-backend/EmailComposer.Backend.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+  </ItemGroup>
 </Project>

--- a/email-composer-backend/Models/SendMailRequest.cs
+++ b/email-composer-backend/Models/SendMailRequest.cs
@@ -9,7 +9,4 @@ public sealed class SendMailRequest
 
     [Required]
     public string BodyHtml { get; set; } = string.Empty;
-
-    [MinLength(1)]
-    public List<string> ToRecipients { get; set; } = [];
 }

--- a/email-composer-backend/Program.cs
+++ b/email-composer-backend/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddCors(options =>
 
 builder.Services.Configure<GraphOptions>(
     builder.Configuration.GetSection(GraphOptions.SectionName));
+builder.Services.AddScoped<SqlRecipientService>();
 builder.Services.AddScoped<GraphMailService>();
 
 var app = builder.Build();

--- a/email-composer-backend/Services/GraphMailService.cs
+++ b/email-composer-backend/Services/GraphMailService.cs
@@ -11,19 +11,23 @@ public sealed class GraphMailService
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly GraphOptions _graphOptions;
+    private readonly SqlRecipientService _recipientService;
 
     public GraphMailService(
         IHttpClientFactory httpClientFactory,
-        IOptions<GraphOptions> graphOptions)
+        IOptions<GraphOptions> graphOptions,
+        SqlRecipientService recipientService)
     {
         _httpClientFactory = httpClientFactory;
         _graphOptions = graphOptions.Value;
+        _recipientService = recipientService;
     }
 
     public async Task SendMailAsync(SendMailRequest request, CancellationToken cancellationToken)
     {
         ValidateSettings();
 
+        var recipients = await _recipientService.GetRecipientEmailAddressesAsync(cancellationToken);
         var accessToken = await GetAccessTokenAsync(cancellationToken);
         var graphClient = _httpClientFactory.CreateClient();
         graphClient.DefaultRequestHeaders.Authorization =
@@ -39,7 +43,7 @@ public sealed class GraphMailService
                     contentType = "HTML",
                     content = request.BodyHtml
                 },
-                toRecipients = request.ToRecipients.Select(email => new
+                toRecipients = recipients.Select(email => new
                 {
                     emailAddress = new
                     {

--- a/email-composer-backend/Services/SqlRecipientService.cs
+++ b/email-composer-backend/Services/SqlRecipientService.cs
@@ -1,0 +1,96 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+
+namespace EmailComposer.Backend.Services;
+
+public sealed class SqlRecipientService
+{
+    private const string ConnectionStringName = "AzureSqlDatabase";
+
+    private const string RecipientEmailQuery = """
+        WITH WorkerRoles AS (
+            SELECT
+                Worker.[Id] AS WorkerId,
+                Worker.[Role] AS RoleName
+            FROM [dbo].[Worker] Worker
+            UNION
+            SELECT
+                Worker.[Id] AS WorkerId,
+                WR.[Name] AS RoleName
+            FROM [dbo].[Worker] Worker
+            LEFT JOIN [dbo].[WorkerRoleAssignment] WRA ON WRA.[WorkerId] = Worker.[Id]
+            INNER JOIN [dbo].[WorkerRole] WR ON WR.[Id] = WRA.[RoleId]
+        ),
+        WorkerRolesAgg AS (
+            SELECT
+                WorkerId,
+                STRING_AGG(RoleName, ', ') AS Roles
+            FROM WorkerRoles
+            GROUP BY WorkerId
+        ),
+        CompanyActiveWfmAdmins AS (
+            SELECT
+                Worker.[EmailAddress]
+            FROM [dbo].[Worker] Worker
+            INNER JOIN WorkerRoles ON WorkerRoles.WorkerId = Worker.[Id]
+            WHERE WorkerRoles.RoleName = 'WFM Administrator' AND Worker.[Status] = 'A'
+        )
+        SELECT DISTINCT
+            EmailAddress
+        FROM CompanyActiveWfmAdmins
+        WHERE EmailAddress IS NOT NULL AND LTRIM(RTRIM(EmailAddress)) <> ''
+        ORDER BY EmailAddress;
+        """;
+
+    private readonly IConfiguration _configuration;
+
+    public SqlRecipientService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public async Task<IReadOnlyList<string>> GetRecipientEmailAddressesAsync(CancellationToken cancellationToken)
+    {
+        var connectionString = _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"Azure SQL connection string is missing. Configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        var recipients = new List<string>();
+        var seenRecipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            await using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new SqlCommand(RecipientEmailQuery, connection);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var emailAddress = reader.GetString(0).Trim();
+                if (seenRecipients.Add(emailAddress))
+                {
+                    recipients.Add(emailAddress);
+                }
+            }
+        }
+        catch (SqlException ex)
+        {
+            throw new InvalidOperationException(
+                "Unable to load recipient email addresses from Azure SQL.",
+                ex);
+        }
+
+        if (recipients.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No active WFM Administrator recipient email addresses were found.");
+        }
+
+        return recipients;
+    }
+}

--- a/email-composer-backend/appsettings.Development.json
+++ b/email-composer-backend/appsettings.Development.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Information"
     }
   },
+  "ConnectionStrings": {
+    "AzureSqlDatabase": ""
+  },
   "Graph": {
     "TenantId": "",
     "ClientId": "",

--- a/email-composer-backend/appsettings.json
+++ b/email-composer-backend/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "AzureSqlDatabase": "Server=tcp:your-server.database.windows.net,1433;Initial Catalog=your-database;Persist Security Info=False;User ID=your-user;Password=your-password;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+  },
   "Graph": {
     "TenantId": "your-tenant-id",
     "ClientId": "your-client-id",

--- a/email-composer-frontend/src/app/app.html
+++ b/email-composer-frontend/src/app/app.html
@@ -2,16 +2,9 @@
   <section class="composer">
     <h1>HTML Email Composer</h1>
     <p>Write a rich email body, insert local images, and send through Graph API.</p>
-
-    <label>
-      To (comma-separated)
-      <input
-        type="text"
-        name="toRecipients"
-        [(ngModel)]="toRecipients"
-        placeholder="recipient1@contoso.com, recipient2@contoso.com"
-      />
-    </label>
+    <p class="recipient-note">
+      Recipients are selected from active WFM Administrators in the configured Azure SQL database.
+    </p>
 
     <label>
       Subject

--- a/email-composer-frontend/src/app/app.scss
+++ b/email-composer-frontend/src/app/app.scss
@@ -25,6 +25,13 @@ p {
   color: #444;
 }
 
+.recipient-note {
+  padding: 0.75rem;
+  background: #eef5ff;
+  border: 1px solid #c7dcff;
+  border-radius: 6px;
+}
+
 label {
   display: grid;
   gap: 0.4rem;

--- a/email-composer-frontend/src/app/app.spec.ts
+++ b/email-composer-frontend/src/app/app.spec.ts
@@ -18,6 +18,6 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, email-composer-frontend');
+    expect(compiled.querySelector('h1')?.textContent).toContain('HTML Email Composer');
   });
 });

--- a/email-composer-frontend/src/app/app.ts
+++ b/email-composer-frontend/src/app/app.ts
@@ -16,7 +16,6 @@ export class App {
   @ViewChild(QuillEditorComponent) editorComponent?: QuillEditorComponent;
   private readonly http = inject(HttpClient);
 
-  toRecipients = '';
   subject = '';
   bodyHtml = '';
   isSending = false;
@@ -45,11 +44,7 @@ export class App {
     try {
       const payload = {
         subject: this.subject,
-        bodyHtml: this.bodyHtml,
-        toRecipients: this.toRecipients
-          .split(',')
-          .map((email) => email.trim())
-          .filter((email) => email.length > 0)
+        bodyHtml: this.bodyHtml
       };
 
       await firstValueFrom(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Azure SQL connection string configuration and Microsoft.Data.SqlClient dependency
- Load active WFM Administrator recipient email addresses from the configured database before sending Graph mail
- Update frontend and API docs so recipients are database-driven instead of request-provided
- Add the missing Swashbuckle package reference required by the existing Swagger setup

## Testing
- `npm run build` (passes with existing bundle budget/CommonJS warnings)
- `npm test -- --watch=false`
- `PATH="$HOME/.dotnet:$PATH" dotnet build "email-composer-backend/EmailComposer.Backend.csproj"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcae49ee-cef9-4d43-ae8c-839163d18121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcae49ee-cef9-4d43-ae8c-839163d18121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

