### PR TITLE
Add organization role dropdown for SQL recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains:
 - Rich text editor for HTML body
 - Insert local image files into editor as inline base64 images
 - Manual comma-separated recipient textbox
-- Optional SQL recipient inclusion (appended to manual recipients when selected)
+- Optional SQL recipient inclusion filtered by selected organization role (appended to manual recipients when selected)
 - Subject field
 - Calls backend endpoint `POST /api/mail/send`
 
@@ -55,7 +55,15 @@ The backend can optionally load recipients from Azure SQL using connection strin
 }
 ```
 
-If the request includes `"includeSqlRecipients": true`, SQL recipients are appended to the manually provided recipients and deduplicated.
+The frontend loads organization role choices from:
+
+```sql
+SELECT distinct [OrganizationRole]
+FROM [dbo].[WorkerRole]
+ORDER BY [OrganizationRole]
+```
+
+If the request includes `"includeSqlRecipients": true`, SQL recipients for the selected `"organizationRole"` are appended to the manually provided recipients and deduplicated.
 
 ### Run
 
@@ -69,6 +77,12 @@ Backend listens on `http://localhost:5000` by default via launch settings.
 
 ## API contract
 
+`GET /api/mail/organization-roles`
+
+```json
+["Accounting", "Operations"]
+```
+
 `POST /api/mail/send`
 
 ```json
@@ -76,6 +90,7 @@ Backend listens on `http://localhost:5000` by default via launch settings.
   "subject": "Hello",
   "bodyHtml": "<p>Message body</p>",
   "toRecipients": ["person@contoso.com", "team@contoso.com"],
-  "includeSqlRecipients": true
+  "includeSqlRecipients": true,
+  "organizationRole": "Operations"
 }
 ```

--- a/email-composer-backend/Controllers/MailController.cs
+++ b/email-composer-backend/Controllers/MailController.cs
@@ -19,6 +19,22 @@ public sealed class MailController : ControllerBase
         _sqlRecipientService = sqlRecipientService;
     }
 
+    [HttpGet("organization-roles")]
+    public async Task<IActionResult> GetOrganizationRoles(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var organizationRoles =
+                await _sqlRecipientService.GetOrganizationRolesAsync(cancellationToken);
+
+            return Ok(organizationRoles);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
     [HttpPost("send")]
     public async Task<IActionResult> SendMail(
         [FromBody] SendMailRequest request,
@@ -34,7 +50,9 @@ public sealed class MailController : ControllerBase
             if (request.IncludeSqlRecipients)
             {
                 var sqlRecipients =
-                    await _sqlRecipientService.GetRecipientEmailAddressesAsync(cancellationToken);
+                    await _sqlRecipientService.GetRecipientEmailAddressesAsync(
+                        request.OrganizationRole ?? string.Empty,
+                        cancellationToken);
 
                 request.ToRecipients = request.ToRecipients
                     .Concat(sqlRecipients)

--- a/email-composer-backend/Models/SendMailRequest.cs
+++ b/email-composer-backend/Models/SendMailRequest.cs
@@ -14,4 +14,6 @@ public sealed class SendMailRequest
     public List<string> ToRecipients { get; set; } = [];
 
     public bool IncludeSqlRecipients { get; set; }
+
+    public string? OrganizationRole { get; set; }
 }

--- a/email-composer-backend/Services/SqlRecipientService.cs
+++ b/email-composer-backend/Services/SqlRecipientService.cs
@@ -7,39 +7,32 @@ public sealed class SqlRecipientService
 {
     private const string ConnectionStringName = "AzureSqlDatabase";
 
+    private const string OrganizationRoleQuery = """
+        SELECT distinct [OrganizationRole]
+        FROM [dbo].[WorkerRole]
+        ORDER BY [OrganizationRole]
+        """;
+
     private const string RecipientEmailQuery = """
         WITH WorkerRoles AS (
             SELECT
                 Worker.[Id] AS WorkerId,
-                Worker.[Role] AS RoleName
-            FROM [dbo].[Worker] Worker
-            UNION
-            SELECT
-                Worker.[Id] AS WorkerId,
-                WR.[Name] AS RoleName
+                WR.[OrganizationRole] AS OrganizationRole
             FROM [dbo].[Worker] Worker
             LEFT JOIN [dbo].[WorkerRoleAssignment] WRA ON WRA.[WorkerId] = Worker.[Id]
             INNER JOIN [dbo].[WorkerRole] WR ON WR.[Id] = WRA.[RoleId]
         ),
-        WorkerRolesAgg AS (
-            SELECT
-                WorkerId,
-                STRING_AGG(RoleName, ', ') AS Roles
-            FROM WorkerRoles
-            GROUP BY WorkerId
-        ),
-        CompanyActiveWfmAdmins AS (
+        ActiveWorkersForOrganizationRole AS (
             SELECT
                 Worker.[EmailAddress]
             FROM [dbo].[Worker] Worker
             INNER JOIN WorkerRoles ON WorkerRoles.WorkerId = Worker.[Id]
-            WHERE WorkerRoles.RoleName = 'WFM Administrator' AND Worker.[Status] = 'A'
+            WHERE WorkerRoles.OrganizationRole = @OrganizationRole AND Worker.[Status] = 'A'
         )
         SELECT DISTINCT
-            'peter.kiedrowski@hatch.com' AS EmailAddress
-        FROM CompanyActiveWfmAdmins
-        --WHERE EmailAddress IS NOT NULL AND LTRIM(RTRIM(EmailAddress)) <> ''
-        --WHERE EmailAddress = 'peter.kiedrowski@hatch.com'
+            EmailAddress
+        FROM ActiveWorkersForOrganizationRole
+        WHERE EmailAddress IS NOT NULL AND LTRIM(RTRIM(EmailAddress)) <> ''
         ORDER BY EmailAddress;
         """;
 
@@ -50,28 +43,56 @@ public sealed class SqlRecipientService
         _configuration = configuration;
     }
 
-    public async Task<IReadOnlyList<string>> GetRecipientEmailAddressesAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<string>> GetOrganizationRolesAsync(CancellationToken cancellationToken)
     {
-        var connectionString = _configuration.GetConnectionString(ConnectionStringName);
-        if (string.IsNullOrWhiteSpace(connectionString))
+        var roles = new List<string>();
+        var seenRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await ExecuteSqlAsync(
+            OrganizationRoleQuery,
+            async command =>
+            {
+                await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    if (reader.IsDBNull(0))
+                    {
+                        continue;
+                    }
+
+                    var organizationRole = reader.GetString(0).Trim();
+                    if (organizationRole.Length > 0 && seenRoles.Add(organizationRole))
+                    {
+                        roles.Add(organizationRole);
+                    }
+                }
+            },
+            "Unable to load organization roles from Azure SQL.",
+            cancellationToken);
+
+        return roles;
+    }
+
+    public async Task<IReadOnlyList<string>> GetRecipientEmailAddressesAsync(
+        string organizationRole,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(organizationRole))
         {
             throw new InvalidOperationException(
-                $"Azure SQL connection string is missing. Configure ConnectionStrings:{ConnectionStringName}.");
+                "Select an organization role before including SQL recipients.");
         }
 
         var recipients = new List<string>();
         var seenRecipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        try
-        {
-            await using var connection = new SqlConnection(connectionString);
-            await connection.OpenAsync(cancellationToken);
-
-            await using var command = new SqlCommand(RecipientEmailQuery, connection);
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
-            if (reader.HasRows)
+        await ExecuteSqlAsync(
+            RecipientEmailQuery,
+            async command =>
             {
+                command.Parameters.AddWithValue("@OrganizationRole", organizationRole.Trim());
+
+                await using var reader = await command.ExecuteReaderAsync(cancellationToken);
                 while (await reader.ReadAsync(cancellationToken))
                 {
                     var emailAddress = reader.GetString(0).Trim();
@@ -80,21 +101,39 @@ public sealed class SqlRecipientService
                         recipients.Add(emailAddress);
                     }
                 }
-            }
+            },
+            "Unable to load recipient email addresses from Azure SQL.",
+            cancellationToken);
+
+        return recipients;
+    }
+
+    private async Task ExecuteSqlAsync(
+        string query,
+        Func<SqlCommand, Task> executeCommand,
+        string errorMessage,
+        CancellationToken cancellationToken)
+    {
+        var connectionString = _configuration.GetConnectionString(ConnectionStringName);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"Azure SQL connection string is missing. Configure ConnectionStrings:{ConnectionStringName}.");
+        }
+
+        try
+        {
+            await using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new SqlCommand(query, connection);
+            await executeCommand(command);
         }
         catch (SqlException ex)
         {
             throw new InvalidOperationException(
-                "Unable to load recipient email addresses from Azure SQL.",
+                errorMessage,
                 ex);
         }
-
-        //if (recipients.Count == 0)
-        //{
-        //    throw new InvalidOperationException(
-        //        "No active WFM Administrator recipient email addresses were found.");
-        //}
-
-        return recipients;
     }
 }

--- a/email-composer-frontend/src/app/app.config.ts
+++ b/email-composer-frontend/src/app/app.config.ts
@@ -1,3 +1,4 @@
+import { provideHttpClient } from '@angular/common/http';
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
@@ -7,6 +8,7 @@ import { routes } from './app.routes';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    provideHttpClient(),
     provideRouter(routes),
     provideAnimations()
   ]

--- a/email-composer-frontend/src/app/app.html
+++ b/email-composer-frontend/src/app/app.html
@@ -35,7 +35,28 @@
         />
         <span>Include SQL recipient list</span>
       </label>
-      <small>Tip: SQL recipients are appended to manual recipients when checked.</small>
+      <label class="organization-role-option">
+        <span>Organization role</span>
+        <select
+          name="organizationRole"
+          [(ngModel)]="selectedOrganizationRole"
+          [disabled]="!includeSqlRecipients || isLoadingOrganizationRoles || organizationRoles.length === 0"
+        >
+          <option value="" disabled>
+            {{ isLoadingOrganizationRoles ? 'Loading organization roles...' : 'Select organizationRole' }}
+          </option>
+          @for (organizationRole of organizationRoles; track organizationRole) {
+            <option [value]="organizationRole">{{ organizationRole }}</option>
+          }
+        </select>
+      </label>
+      <small>
+        @if (organizationRolesLoadFailed) {
+          Unable to load organization roles.
+        } @else {
+          SQL recipients are appended to manual recipients when checked.
+        }
+      </small>
     </div>
 
     <section class="editor-shell">

--- a/email-composer-frontend/src/app/app.scss
+++ b/email-composer-frontend/src/app/app.scss
@@ -65,7 +65,8 @@ label {
 }
 
 input[type='text'],
-input[type='file'] {
+input[type='file'],
+select {
   font: inherit;
   padding: 0.7rem 0.8rem;
   border: 1px solid rgb(148 163 184 / 45%);
@@ -75,9 +76,15 @@ input[type='file'] {
 }
 
 input[type='text']:focus,
-input[type='file']:focus {
+input[type='file']:focus,
+select:focus {
   outline: 2px solid #8b5cf6;
   outline-offset: 1px;
+}
+
+select:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
 }
 
 .toolbar-row {
@@ -106,6 +113,10 @@ input[type='file']:focus {
 .sql-option input[type='checkbox'] {
   width: 1rem;
   height: 1rem;
+}
+
+.organization-role-option {
+  min-width: min(280px, 100%);
 }
 
 .image-input {

--- a/email-composer-frontend/src/app/app.spec.ts
+++ b/email-composer-frontend/src/app/app.spec.ts
@@ -16,35 +16,38 @@ describe('App', () => {
     TestBed.inject(HttpTestingController).verify();
   });
 
-  it('should create the app', () => {
+  it('should create the app', async () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     TestBed.inject(HttpTestingController)
       .expectOne(`${environment.apiBaseUrl}/api/mail/organization-roles`)
       .flush([]);
+    await fixture.whenStable();
 
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render title', async () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     TestBed.inject(HttpTestingController)
       .expectOne(`${environment.apiBaseUrl}/api/mail/organization-roles`)
       .flush([]);
+    await fixture.whenStable();
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('HTML Email Composer');
   });
 
-  it('should render organization role options from the API', () => {
+  it('should render organization role options from the API', async () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     TestBed.inject(HttpTestingController)
       .expectOne(`${environment.apiBaseUrl}/api/mail/organization-roles`)
       .flush(['Accounting', 'Operations']);
+    await fixture.whenStable();
     fixture.detectChanges();
 
     const options = Array.from(

--- a/email-composer-frontend/src/app/app.spec.ts
+++ b/email-composer-frontend/src/app/app.spec.ts
@@ -1,23 +1,57 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { App } from './app';
+import { environment } from '../environments/environment';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
     }).compileComponents();
+  });
+
+  afterEach(() => {
+    TestBed.inject(HttpTestingController).verify();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController)
+      .expectOne(`${environment.apiBaseUrl}/api/mail/organization-roles`)
+      .flush([]);
+
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it('should render title', async () => {
+  it('should render title', () => {
     const fixture = TestBed.createComponent(App);
-    await fixture.whenStable();
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController)
+      .expectOne(`${environment.apiBaseUrl}/api/mail/organization-roles`)
+      .flush([]);
+    fixture.detectChanges();
+
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, email-composer-frontend');
+    expect(compiled.querySelector('h1')?.textContent).toContain('HTML Email Composer');
+  });
+
+  it('should render organization role options from the API', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController)
+      .expectOne(`${environment.apiBaseUrl}/api/mail/organization-roles`)
+      .flush(['Accounting', 'Operations']);
+    fixture.detectChanges();
+
+    const options = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('select[name="organizationRole"] option')
+    ).map((option) => option.textContent?.trim());
+
+    expect(options).toContain('Accounting');
+    expect(options).toContain('Operations');
   });
 });

--- a/email-composer-frontend/src/app/app.ts
+++ b/email-composer-frontend/src/app/app.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { Component, ViewChild, inject } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { QuillEditorComponent, QuillModule } from 'ngx-quill';
 import Quill from 'quill';
@@ -12,12 +12,16 @@ import { environment } from '../environments/environment';
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
-export class App {
+export class App implements OnInit {
   @ViewChild(QuillEditorComponent) editorComponent?: QuillEditorComponent;
   private readonly http = inject(HttpClient);
 
   toRecipients = '';
   includeSqlRecipients = false;
+  organizationRoles: string[] = [];
+  selectedOrganizationRole = '';
+  isLoadingOrganizationRoles = false;
+  organizationRolesLoadFailed = false;
   subject = '';
   bodyHtml = '';
   isSending = false;
@@ -35,12 +39,22 @@ export class App {
     ]
   };
 
+  ngOnInit(): void {
+    void this.loadOrganizationRoles();
+  }
+
   async sendMail(): Promise<void> {
     if (this.isSending) {
       return;
     }
 
     this.statusMessage = '';
+
+    if (this.includeSqlRecipients && !this.selectedOrganizationRole) {
+      this.statusMessage = 'Select an organization role before sending to SQL recipients.';
+      return;
+    }
+
     this.isSending = true;
 
     try {
@@ -48,6 +62,7 @@ export class App {
         subject: this.subject,
         bodyHtml: this.bodyHtml,
         includeSqlRecipients: this.includeSqlRecipients,
+        organizationRole: this.includeSqlRecipients ? this.selectedOrganizationRole : null,
         toRecipients: this.toRecipients
           .split(',')
           .map((email) => email.trim())
@@ -86,6 +101,22 @@ export class App {
       editor.setSelection(index + 1, 0, Quill.sources.SILENT);
     } finally {
       input.value = '';
+    }
+  }
+
+  private async loadOrganizationRoles(): Promise<void> {
+    this.isLoadingOrganizationRoles = true;
+    this.organizationRolesLoadFailed = false;
+
+    try {
+      this.organizationRoles = await firstValueFrom(
+        this.http.get<string[]>(`${environment.apiBaseUrl}/api/mail/organization-roles`)
+      );
+    } catch {
+      this.organizationRoles = [];
+      this.organizationRolesLoadFailed = true;
+    } finally {
+      this.isLoadingOrganizationRoles = false;
     }
   }
 

--- a/email-composer-frontend/src/app/app.ts
+++ b/email-composer-frontend/src/app/app.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { QuillEditorComponent, QuillModule } from 'ngx-quill';
@@ -8,7 +8,7 @@ import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
-  imports: [FormsModule, HttpClientModule, QuillModule],
+  imports: [FormsModule, QuillModule],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an API endpoint that returns distinct organization roles from WorkerRole.
- Send the selected organizationRole with mail requests and filter SQL recipients by it.
- Add an Angular dropdown for selecting organizationRole and update docs/tests.

## Verification
- `dotnet build`
- `npm run build` (passes with existing bundle budget and quill-delta CommonJS warnings)
- `npm test -- --watch=false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-814cbb9f-5b37-4d56-9d75-e136b37af116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-814cbb9f-5b37-4d56-9d75-e136b37af116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

